### PR TITLE
Add bolded prompt segments excluding hostname

### DIFF
--- a/.poshthemes/tokyo.omp.json
+++ b/.poshthemes/tokyo.omp.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/schema.json",
+  "blocks": [
+    {
+      "type": "prompt",
+      "alignment": "left",
+      "segments": [
+        {
+          "type": "path",
+          "style": "powerline",
+          "background": "#44475a",
+          "foreground": "#f8f8f2",
+          "template": "{{ .Path | bold }}"
+        },
+        {
+          "type": "git",
+          "style": "powerline",
+          "background": "#bd93f9",
+          "foreground": "#f8f8f2",
+          "template": "{{ .HEAD | bold }}"
+        },
+        {
+          "type": "hostname",
+          "style": "powerline",
+          "background": "#6272a4",
+          "foreground": "#f8f8f2",
+          "template": "{{ .Host }}"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add custom oh-my-posh theme making path and git segments bold while leaving hostname normal

## Testing
- `jq . .poshthemes/tokyo.omp.json`
- `python -m py_compile hello_world.py`


------
https://chatgpt.com/codex/tasks/task_e_68a57410bf5c8333bc6d6210f4d8112e